### PR TITLE
Remove user-read-birthdate scope because due to changes by Spotify

### DIFF
--- a/gotify.go
+++ b/gotify.go
@@ -138,7 +138,6 @@ func (c *Client) AuthURL() string {
 		values.UserLibraryRead,
 		values.UserLibraryModify,
 		values.UserReadPrivate,
-		values.UserReadBirthdate,
 		values.UserReadEmail,
 		values.UserTopRead,
 		values.UserReadPlaybackState,

--- a/models/currentUsersProfile.go
+++ b/models/currentUsersProfile.go
@@ -2,7 +2,6 @@ package models
 
 // CurrentUsersProfile : the struct for GET https://api.spotify.com/v1/me
 type CurrentUsersProfile struct {
-	Birthdate    string `json:"birthdate"`
 	Country      string `json:"country"`
 	DisplayName  string `json:"display_name"`
 	Email        string `json:"email"`

--- a/values/scope.go
+++ b/values/scope.go
@@ -34,9 +34,6 @@ const (
 	// UserReadPrivate : Read access to user’s subscription details (type of user account).
 	UserReadPrivate = "user-read-private"
 
-	// UserReadBirthdate : Read access to the user's birthdate.
-	UserReadBirthdate = "user-read-birthdate"
-
 	// UserReadEmail : Read access to user’s email address.
 	UserReadEmail = "user-read-email"
 


### PR DESCRIPTION
Last year, Spotify removed `user-read-birthdate` from [authorization scope](https://developer.spotify.com/documentation/general/guides/scopes).
Therefore, it appears as an invalid scope during authentication like https://github.com/spotify/web-api/issues/1322.
This pull request removes `user-read-birthdate` from the scope used during authentication.