### PR TITLE
Add '/' between callback uri and scope

### DIFF
--- a/gotify.go
+++ b/gotify.go
@@ -125,7 +125,7 @@ func Set(clientID string, clientSecret string, callbackURI string) OAuth {
 func (c *Client) AuthURL() string {
 	responseType := "code"
 	and := "%20"
-	redirectURL := "https://accounts.spotify.com/authorize/?client_id=" + c.ClientID + "&response_type=" + responseType + "&redirect_uri=" + c.CallbackURI + "&scope=" //"user-read-private%20user-library-read%20user-follow-read"
+	redirectURL := "https://accounts.spotify.com/authorize/?client_id=" + c.ClientID + "&response_type=" + responseType + "&redirect_uri=" + c.CallbackURI + "/&scope=" //"user-read-private%20user-library-read%20user-follow-read"
 
 	scopes := []string{values.PlaylistReadPrivate,
 		values.PlaylistReadCollaborative,


### PR DESCRIPTION
There is a bug that is displayed as `INVALID_CLIENT: Invalid redirect URI` when redirecting.
This is because the redirect URL is not correct, and '/' is missing between callback uri and scope.
This pull request fixes it and changes it to redirect to the correct URL.